### PR TITLE
feat: add docker binary to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 RUN apt update; apt dist-upgrade -y
 RUN apt install -y curl wget git zip
 
+# Install Docker (for authenticating to private container registries)
+RUN apt-get install -y docker docker.io containerd runc
+
 # Install Syft
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/bin
 


### PR DESCRIPTION
I forked the repo to try out scanning our internal docker containers.
That worked really well, and the results looks promising at first glance - great job so far!
I think it makes sense to add docker-login capabilities as a general feature, since that will be required for scanning anything non-public.

This PR adds that.